### PR TITLE
fix #3 - an AttributeError in the on_message listener

### DIFF
--- a/counting/counting.py
+++ b/counting/counting.py
@@ -47,7 +47,7 @@ class Counting(commands.Cog):
     @commands.Cog.listener()
     async def on_message(self, message):
         """Handles messages in the counting game channel."""
-        if message.author.bot:
+        if message.author.bot or message.guild is None:
             return
 
         guild_config = await self.config.guild(message.guild).all()


### PR DESCRIPTION
the `on_message` listener previously did not check if the `guild` attribute of the `message` object exists before trying to use it. this caused an AttributeError to be thrown if the bot received a direct message, as the `guild` attribute is `None` in that case. this pr fixes that behavior, so it also closes #3.
here's a sentry report of the bug: https://sentry.csw.im/share/issue/5746ba2da3624609bc6fc5cdc6566ff8/