### PR TITLE
fix console error when messages sent in dms 

### DIFF
--- a/counting/counting.py
+++ b/counting/counting.py
@@ -47,7 +47,7 @@ class Counting(commands.Cog):
     @commands.Cog.listener()
     async def on_message(self, message):
         """Handles messages in the counting game channel."""
-        if message.author.bot:
+        if message.author.bot or message.guild is None:  # Check if the message is from a guild or a bot
             return
 
         guild_config = await self.config.guild(message.guild).all()


### PR DESCRIPTION
fixes 

#5798 [2024-09-01 16:27:16] ERROR [discord.client] Ignoring exception in on_message.

Traceback (most recent call last):
File "{HOME}/redenv/lib/python3.11/site-packages/discord/client.py", line 449, in _run_event
await coro(*args, **kwargs)
File "{HOME}/.local/share/Red-DiscordBot/data/jarvis/cogs/CogManager/cogs/counting/counting.py", line 53, in on_message
guild_config = await self.config.guild(message.guild).all()
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "{HOME}/redenv/lib/python3.11/site-packages/redbot/core/config.py", line 991, in guild
return self._get_base_group(self.GUILD, str(guild.id))
^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'id'
